### PR TITLE
Make bitmap creation faster

### DIFF
--- a/CDiRipper/CDiRipper.csproj
+++ b/CDiRipper/CDiRipper.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/CDiRipper/FormMain.Designer.cs
+++ b/CDiRipper/FormMain.Designer.cs
@@ -29,69 +29,74 @@ namespace CDiRipper
         /// </summary>
         private void InitializeComponent()
         {
-            this.buttonLoad = new System.Windows.Forms.Button();
-            this.pictureBoxImage = new System.Windows.Forms.PictureBox();
-            this.listBoxIndex = new System.Windows.Forms.ListBox();
-            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxImage)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // buttonLoad
-            // 
-            this.buttonLoad.Location = new System.Drawing.Point(12, 12);
-            this.buttonLoad.Name = "buttonLoad";
-            this.buttonLoad.Size = new System.Drawing.Size(75, 23);
-            this.buttonLoad.TabIndex = 0;
-            this.buttonLoad.Text = "Load...";
-            this.buttonLoad.UseVisualStyleBackColor = true;
-            this.buttonLoad.Click += new System.EventHandler(this.buttonLoad_Click);
-            // 
-            // pictureBoxImage
-            // 
-            this.pictureBoxImage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			this.buttonLoad = new System.Windows.Forms.Button();
+			this.pictureBoxImage = new System.Windows.Forms.PictureBox();
+			this.listBoxIndex = new System.Windows.Forms.ListBox();
+			this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+			((System.ComponentModel.ISupportInitialize)(this.pictureBoxImage)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// buttonLoad
+			// 
+			this.buttonLoad.Location = new System.Drawing.Point(12, 12);
+			this.buttonLoad.Name = "buttonLoad";
+			this.buttonLoad.Size = new System.Drawing.Size(75, 23);
+			this.buttonLoad.TabIndex = 0;
+			this.buttonLoad.Text = "Load...";
+			this.buttonLoad.UseVisualStyleBackColor = true;
+			this.buttonLoad.Click += new System.EventHandler(this.buttonLoad_Click);
+			// 
+			// pictureBoxImage
+			// 
+			this.pictureBoxImage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.pictureBoxImage.BackColor = System.Drawing.SystemColors.ControlDark;
-            this.pictureBoxImage.Location = new System.Drawing.Point(142, 48);
-            this.pictureBoxImage.Name = "pictureBoxImage";
-            this.pictureBoxImage.Size = new System.Drawing.Size(384, 280);
-            this.pictureBoxImage.TabIndex = 1;
-            this.pictureBoxImage.TabStop = false;
-            // 
-            // listBoxIndex
-            // 
-            this.listBoxIndex.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			this.pictureBoxImage.BackColor = System.Drawing.SystemColors.ControlDark;
+			this.pictureBoxImage.Location = new System.Drawing.Point(142, 48);
+			this.pictureBoxImage.Name = "pictureBoxImage";
+			this.pictureBoxImage.Size = new System.Drawing.Size(384, 280);
+			this.pictureBoxImage.TabIndex = 1;
+			this.pictureBoxImage.TabStop = false;
+			// 
+			// listBoxIndex
+			// 
+			this.listBoxIndex.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
-            this.listBoxIndex.FormattingEnabled = true;
-            this.listBoxIndex.Location = new System.Drawing.Point(12, 51);
-            this.listBoxIndex.Name = "listBoxIndex";
-            this.listBoxIndex.Size = new System.Drawing.Size(120, 277);
-            this.listBoxIndex.TabIndex = 2;
-            this.listBoxIndex.SelectedIndexChanged += new System.EventHandler(this.listBoxIndex_SelectedIndexChanged);
-            // 
-            // numericUpDown1
-            // 
-            this.numericUpDown1.Location = new System.Drawing.Point(142, 15);
-            this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Size = new System.Drawing.Size(120, 20);
-            this.numericUpDown1.TabIndex = 3;
-            this.numericUpDown1.ValueChanged += new System.EventHandler(this.numericUpDown1_ValueChanged);
-            // 
-            // FormMain
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(538, 340);
-            this.Controls.Add(this.numericUpDown1);
-            this.Controls.Add(this.listBoxIndex);
-            this.Controls.Add(this.pictureBoxImage);
-            this.Controls.Add(this.buttonLoad);
-            this.Name = "FormMain";
-            this.Text = "CD-i Ripper";
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxImage)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
-            this.ResumeLayout(false);
+			this.listBoxIndex.FormattingEnabled = true;
+			this.listBoxIndex.Location = new System.Drawing.Point(12, 51);
+			this.listBoxIndex.Name = "listBoxIndex";
+			this.listBoxIndex.Size = new System.Drawing.Size(120, 277);
+			this.listBoxIndex.TabIndex = 2;
+			this.listBoxIndex.SelectedIndexChanged += new System.EventHandler(this.listBoxIndex_SelectedIndexChanged);
+			// 
+			// numericUpDown1
+			// 
+			this.numericUpDown1.Location = new System.Drawing.Point(142, 15);
+			this.numericUpDown1.Maximum = new decimal(new int[] {
+            10000,
+            0,
+            0,
+            0});
+			this.numericUpDown1.Name = "numericUpDown1";
+			this.numericUpDown1.Size = new System.Drawing.Size(120, 20);
+			this.numericUpDown1.TabIndex = 3;
+			this.numericUpDown1.ValueChanged += new System.EventHandler(this.numericUpDown1_ValueChanged);
+			// 
+			// FormMain
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(538, 340);
+			this.Controls.Add(this.numericUpDown1);
+			this.Controls.Add(this.listBoxIndex);
+			this.Controls.Add(this.pictureBoxImage);
+			this.Controls.Add(this.buttonLoad);
+			this.Name = "FormMain";
+			this.Text = "CD-i Ripper";
+			((System.ComponentModel.ISupportInitialize)(this.pictureBoxImage)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
+			this.ResumeLayout(false);
 
         }
 

--- a/CDiRipper/FormMain.cs
+++ b/CDiRipper/FormMain.cs
@@ -49,12 +49,16 @@ namespace CDiRipper
         {
             //pictureBoxImage.Image = Image.GetIDAT(Program.LoadedFile.Data, Program.LoadedFile.IDATSectors[listBoxIndex.SelectedIndex]);
             numericUpDown1.Value = 0;
+			if(pictureBoxImage.Image != null)
+				pictureBoxImage.Image.Dispose();
             pictureBoxImage.Image = Program.LoadedFile.GetImage(Program.LoadedFile.RTStartSectors[listBoxIndex.SelectedIndex], (int)numericUpDown1.Value);
         }
 
         private void numericUpDown1_ValueChanged(object sender, EventArgs e)
         {
             //pictureBoxImage.Image = Image.GetIDAT(Program.LoadedFile.Data, Program.LoadedFile.IDATSectors[listBoxIndex.SelectedIndex]);
+			if(pictureBoxImage.Image != null)
+				pictureBoxImage.Image.Dispose();
             pictureBoxImage.Image = Program.LoadedFile.GetImage(Program.LoadedFile.RTStartSectors[listBoxIndex.SelectedIndex], (int)numericUpDown1.Value);
         }
     }

--- a/CDiRipper/Image.cs
+++ b/CDiRipper/Image.cs
@@ -24,7 +24,7 @@ namespace CDiRipper
                 int b = sectorData[(i * 3) + 2 + offset];
                 pal[i] = Color.FromArgb(r, g, b);
             }
-
+			
             return pal;
         }
 
@@ -38,6 +38,7 @@ namespace CDiRipper
             int height = 280;
 
             Bitmap output = new Bitmap(width, height);
+			var bm = output.LockBits(new Rectangle(0, 0, width, height), System.Drawing.Imaging.ImageLockMode.ReadWrite, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 
             //Check for IDAT
             int offset = 0;
@@ -64,17 +65,21 @@ namespace CDiRipper
 
                 while (nb > 1)
                 {
-                    if ((i / width) >= height) return output;
-                    output.SetPixel(i % width, i / width, palette[dat & 0x7F]);
+                    if ((i / width) >= height) goto end;
+                    //output.SetPixel(i % width, i / width, palette[dat & 0x7F]);
+					SetBitmapPixel(bm, i, palette[dat & 0x7F]);
                     i++;
                     nb--;
                 }
 
-                if ((i / width) >= height) return output;
+                if ((i / width) >= height) goto end;
 
-                output.SetPixel(i % width, i / width, palette[dat & 0x7F]);
+                //output.SetPixel(i % width, i / width, palette[dat & 0x7F]);
+				SetBitmapPixel(bm, i, palette[dat & 0x7F]);
             }
-
+end:
+			dataArray.Dispose();
+			output.UnlockBits(bm);
             return output;
         }
 
@@ -88,6 +93,7 @@ namespace CDiRipper
             int height = 280;
 
             Bitmap output = new Bitmap(width, height);
+			var bm = output.LockBits(new Rectangle(0, 0, width, height), System.Drawing.Imaging.ImageLockMode.ReadWrite, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 
             //Check for IDAT
             int offset = 0;
@@ -104,10 +110,20 @@ namespace CDiRipper
             {
                 int dat = dataArray.ReadByte();
                 if (dat == -1) break;
-                output.SetPixel(i % width, i / width, palette[dat & 0x7F]);
+                //output.SetPixel(i % width, i / width, palette[dat & 0x7F]);
+				SetBitmapPixel(bm, i, palette[dat & 0x7F]);
             }
-
+			dataArray.Dispose();
+			output.UnlockBits(bm);
             return output;
         }
+
+		public unsafe static void SetBitmapPixel(System.Drawing.Imaging.BitmapData bm, int pixel, Color clr)
+		{
+			*(byte*)(bm.Scan0 + pixel * 4 + 0) = clr.B;
+			*(byte*)(bm.Scan0 + pixel * 4 + 1) = clr.G;
+			*(byte*)(bm.Scan0 + pixel * 4 + 2) = clr.R;
+			*(byte*)(bm.Scan0 + pixel * 4 + 3) = clr.A;
+		}
     }
 }

--- a/CDiRipper/Program.cs
+++ b/CDiRipper/Program.cs
@@ -70,7 +70,8 @@ namespace CDiRipper
                 byte submode = sectorData[18];
 
                 //Check if the Data is real time
-                if ((submode & 0b01000000) == 0) break;
+				//0b01000000
+                if ((submode & 64) == 0) break;
 
                 //Check for Data Type
                 if ((submode & 0x0E) == 8) break;    //Data
@@ -81,7 +82,8 @@ namespace CDiRipper
                 data.AddRange(GetSubarray(sectorData, 24, 0x930 - 24 - 4));
 
                 //Check for End
-                if ((submode & 0b10000001) != 0) break;
+				//0b10000001
+                if ((submode & 129) != 0) break;
                 //if (data.Count >= length) break;
             } while (true);
 


### PR DESCRIPTION
SetPixel is a slow method, it's better to set the raw data. I had to change the binary literals to the normal number because VS2013 for some reason doesn't like that, if that bothers you a lot just change it back if this merges.

I changed the id number box limit to a big one too but I forgot to put that in the commit message.